### PR TITLE
Fix reinstate battery treshold

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -154,15 +154,17 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 	}
 
 	_set_bpm(low, high) {
-		let file = Gio.File.new_for_path("/sys/devices/platform/huawei-wmi/charge_control_thresholds");
+		let file_sys = Gio.File.new_for_path("/sys/devices/platform/huawei-wmi/charge_control_thresholds");
+		let file_def = Gio.File.new_for_path("/etc/default/huawei-wmi/charge_control_thresholds");
 
 		if (low || high)
 			try {
-				file.replace_contents(`${low} ${high}`, null, false, 0, null);
+				file_sys.replace_contents(`${low} ${high}`, null, false, 0, null);
+				file_def.replace_contents(`${low} ${high}`, null, false, 0, null);
 			} catch (e) {}
 
 		try {
-			[low, high] = ByteArray.toString(file.load_contents(null)[1]).split(' ').map(Number);
+			[low, high] = ByteArray.toString(file_sys.load_contents(null)[1]).split(' ').map(Number);
 		} catch (e) {
 			this._bpm.setSensitive(false);
 			this._bpm.label.set_text(this._BPM);


### PR DESCRIPTION
I have been having some issues with the battery charging tresholds resetting on reboot for a while now. Can't remember when it showed up or if the problem even stems from this extension or qu1x's project [https://github.com/qu1x/huawei-wmi](https://github.com/qu1x/huawei-wmi).

The issue seems easy enough to fix by making this extension also modify the treshold values residing in `/etc/default/huawei-wmi/charge_control_thresholds` used by `huawei-wmi-reinstate.service` to set the tresholds on sleep/boot etc.