### PR TITLE
Replace center box background coloring with camera indicator

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -290,6 +290,10 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
         }
 				this._camera_hint_timeout = null;
 				Main.panel._centerBox.set_style(null);
+
+        this._camera_indicator?.show_warning(CAMERA_ICONS.EJECTED);
+        this._show_osd(CAMERA_ICONS.EJECTED, _("No Camera detected"));
+
 				return GLib.SOURCE_REMOVE;
 			});
 		}
@@ -337,6 +341,15 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		this._show_osd(CAMERA_ICONS.DETACHED, _("Camera detached"));
 
 		this._camera_indicator?.show_hint(CAMERA_ICONS.DETACHED);
+
+  		if (this._camera_hint_timeout === null) {
+			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
+				this._camera_hint_timeout = null;
+				this._camera_indicator?.show_warning(CAMERA_ICONS.DETACHED);
+				this._show_osd(CAMERA_ICONS.DETACHED, _("No Camera detected"));
+				return GLib.SOURCE_REMOVE;
+			});
+		}
 	}
 
 	_update() {

--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,6 @@
 
 import St from 'gi://St';
 import Gio from 'gi://Gio';
-import Cogl from 'gi://Cogl';
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
@@ -105,7 +104,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		if (this._fullscreen_changed_s !== null) Display.disconnect(this._fullscreen_changed_s);
 		if (this._fn_led_timeout !== null) GLib.Source.remove(this._fn_led_timeout);
 		if (this._camera_hint_timeout !== null) GLib.Source.remove(this._camera_hint_timeout);
-		if (this._camera_hint_prev_color !== null) Main.panel._centerBox.set_background_color(this._camera_hint_prev_color);
+		if (this._camera_hint_prev_color !== null) Main.panel._centerBox.set_style(null);
 
 		super.destroy();
 	}
@@ -175,15 +174,16 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 		if (this._camera_hint_timeout === null) {
 			this._camera_hint_prev_color = Main.panel._centerBox.get_background_color();
-			Main.panel._centerBox.set_background_color(Cogl.color_from_string('#00AAD0')[1]);
+			Main.panel._centerBox.set_style('background-color: #00AAD0;');
 
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 10, () => {
 				this._camera_hint_timeout = null;
 
 				if (this._camera_hint_prev_color !== null) {
-					Main.panel._centerBox.set_background_color(this._camera_hint_prev_color);
+					Main.panel._centerBox.set_style(null);
 					this._camera_hint_prev_color = null;
 				}
+				return GLib.SOURCE_REMOVE;
 			});
 		}
 	}
@@ -197,7 +197,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		}
 
 		if (this._camera_hint_prev_color !== null) {
-			Main.panel._centerBox.set_background_color(this._camera_hint_prev_color);
+			Main.panel._centerBox.set_style(null);
 			this._camera_hint_prev_color = null;
 		}
 	}
@@ -211,7 +211,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		}
 
 		if (this._camera_hint_prev_color !== null) {
-			Main.panel._centerBox.set_background_color(this._camera_hint_prev_color);
+			Main.panel._centerBox.set_style(null);
 			this._camera_hint_prev_color = null;
 		}
 	}

--- a/extension.js
+++ b/extension.js
@@ -32,7 +32,7 @@ class NonClosingPopupSwitchMenuItem extends PopupMenu.PopupSwitchMenuItem {
 });
 
 const BLUE_GLOW_STYLE = `
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: transparent;
     box-shadow: inset 0 8px 6px -4px rgba(0, 200, 255, 0.9);
     border-radius: 0 0 99px 99px;
     border: none;

--- a/extension.js
+++ b/extension.js
@@ -31,6 +31,13 @@ class NonClosingPopupSwitchMenuItem extends PopupMenu.PopupSwitchMenuItem {
 	}
 });
 
+const BLUE_GLOW_STYLE = `
+    background-color: rgba(0, 0, 0, 0.2);
+    box-shadow: inset 0 8px 6px -4px rgba(0, 200, 255, 0.9);
+    border-radius: 0 0 99px 99px;
+    border: none;
+`;
+
 const CAMERA_NOTIFICATION_DURATION = 10;
 
 const CAMERA_ICONS = {
@@ -41,10 +48,10 @@ const CAMERA_ICONS = {
     DEFAULT: 'camera-photo-symbolic'
 };
 
-const COLOR_HIGHLIGHT = '#3D7FFF'
-const COLOR_WARNING = '#EB642A'
-const COLOR_HINT = '#828284'
-const COLOR_INFO = null
+const COLOR_HIGHLIGHT = '#3D7FFF';
+const COLOR_WARNING = '#EB642A';
+const COLOR_HINT = '#828284';
+const COLOR_INFO = null;
 
 const CameraIndicator = GObject.registerClass(
 class CameraIndicator extends PanelMenu.Button {
@@ -265,7 +272,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 		if (this._camera_hint_timeout === null) {
 			this._camera_hint_prev_color = Main.panel._centerBox.get_background_color();
-			Main.panel._centerBox.set_style('background-color: #00AAD0;');
+			Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
 
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
 				this._camera_hint_timeout = null;

--- a/extension.js
+++ b/extension.js
@@ -38,6 +38,8 @@ const BLUE_GLOW_STYLE = `
     border: none;
 `;
 
+const BLUE_GLOW_BLINKING_INTERVAL = 1000;
+
 const CAMERA_NOTIFICATION_DURATION = 10;
 
 const CAMERA_ICONS = {
@@ -189,7 +191,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		this._fn_led_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT_IDLE, 250, () => this._update_fn_led() || true);
 
 		this._camera_hint_timeout = null;
-		this._camera_hint_prev_color = null;
+		this._camera_blink_timer = null;
 
 		this._bind_keys(settings);
 
@@ -201,8 +203,9 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 		if (this._fullscreen_changed_s !== null) Display.disconnect(this._fullscreen_changed_s);
 		if (this._fn_led_timeout !== null) GLib.Source.remove(this._fn_led_timeout);
+		if (this._camera_blink_timer) GLib.Source.remove(this._camera_blink_timer);
 		if (this._camera_hint_timeout !== null) GLib.Source.remove(this._camera_hint_timeout);
-		if (this._camera_hint_prev_color !== null) Main.panel._centerBox.set_style(null);
+		Main.panel._centerBox.set_style(null);
 
 		super.destroy();
 	}
@@ -270,17 +273,23 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 	_camera_ejected() {
 		this._show_osd(CAMERA_ICONS.EJECTED, _("Camera ejected"));
 
-		if (this._camera_hint_timeout === null) {
-			this._camera_hint_prev_color = Main.panel._centerBox.get_background_color();
-			Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
+    if (this._camera_hint_timeout === null) {
+      let isGlowVisible = true;
+      Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
+
+      this._camera_blink_timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, BLUE_GLOW_BLINKING_INTERVAL, () => {
+          isGlowVisible = !isGlowVisible;
+          Main.panel._centerBox.set_style(isGlowVisible ? BLUE_GLOW_STYLE : null);
+          return GLib.SOURCE_CONTINUE;
+      });
 
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
+				if (this._camera_blink_timer) {
+          GLib.Source.remove(this._camera_blink_timer);
+          this._camera_blink_timer = null;
+        }
 				this._camera_hint_timeout = null;
-
-				if (this._camera_hint_prev_color !== null) {
-					Main.panel._centerBox.set_style(null);
-					this._camera_hint_prev_color = null;
-				}
+				Main.panel._centerBox.set_style(null);
 				return GLib.SOURCE_REMOVE;
 			});
 		}
@@ -296,10 +305,12 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			this._camera_hint_timeout = null;
 		}
 
-		if (this._camera_hint_prev_color !== null) {
-			Main.panel._centerBox.set_style(null);
-			this._camera_hint_prev_color = null;
-		}
+		if (this._camera_blink_timer) {
+			GLib.Source.remove(this._camera_blink_timer);
+			this._camera_blink_timer = null;
+    }
+
+		Main.panel._centerBox.set_style(null);
 
 		this._camera_indicator?.show_info(CAMERA_ICONS.INSERTED);
 	}
@@ -312,10 +323,12 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			this._camera_hint_timeout = null;
 		}
 
-		if (this._camera_hint_prev_color !== null) {
-			Main.panel._centerBox.set_style(null);
-			this._camera_hint_prev_color = null;
+		if (this._camera_blink_timer) {
+			GLib.Source.remove(this._camera_blink_timer);
+			this._camera_blink_timer = null;
 		}
+
+		Main.panel._centerBox.set_style(null);
 
 		this._camera_indicator?.show_highlight(CAMERA_ICONS.ATTACHED);
 	}

--- a/extension.js
+++ b/extension.js
@@ -31,6 +31,96 @@ class NonClosingPopupSwitchMenuItem extends PopupMenu.PopupSwitchMenuItem {
 	}
 });
 
+const CAMERA_NOTIFICATION_DURATION = 10;
+
+const CAMERA_ICONS = {
+    EJECTED: 'camera-photo-symbolic',
+    INSERTED: 'camera-hardware-disabled-symbolic',
+    ATTACHED: 'camera-photo-symbolic',
+    DETACHED: 'camera-hardware-disabled-symbolic',
+    DEFAULT: 'camera-photo-symbolic'
+};
+
+const COLOR_HIGHLIGHT = '#3D7FFF'
+const COLOR_WARNING = '#EB642A'
+const COLOR_HINT = '#828284'
+const COLOR_INFO = null
+
+const CameraIndicator = GObject.registerClass(
+class CameraIndicator extends PanelMenu.Button {
+	_init() {
+		super._init(0.0, _("Camera"));
+
+		this._timeout = null;
+
+		this.add_style_class_name('panel-button');
+
+		this.icon = new St.Icon({
+			icon_name: CAMERA_ICONS.DEFAULT,
+			style_class: 'system-status-icon',
+		});
+
+		this._icon_box = new St.BoxLayout({
+		  style_class: 'panel-status-menu-box',
+		});
+
+		this._icon_box.add_child(this.icon);
+		this.add_child(this._icon_box);
+
+		this.opacity = 0;
+    this.reactive = false;
+	}
+
+	destroy() {
+		if (this._timeout !== null) {
+			GLib.Source.remove(this._timeout);
+			this._timeout = null;
+		}
+		super.destroy();
+	}
+
+	show_indicator({ durationSeconds = CAMERA_NOTIFICATION_DURATION, bgColor = null, color = null, iconName = null} = {}) {
+		if (iconName) this.icon.icon_name = iconName;
+		this.set_style(`
+      background-color: ${bgColor};
+      color: ${color};
+      transition-duration: 0ms;
+    `);
+
+		this.opacity = 255;
+    this.reactive = true;
+
+        if (this._timeout !== null) {
+			GLib.Source.remove(this._timeout);
+		}
+
+		this._timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, durationSeconds, () => {
+			this._timeout = null;
+			this.opacity = 0;
+      this.reactive = false;
+ 			this.set_style(null);
+			this.icon.icon_name = CAMERA_ICONS.DEFAULT;
+			return GLib.SOURCE_REMOVE;
+		});
+	}
+
+	show_info(iconName = null) {
+    this.show_indicator({ iconName: iconName });
+	}
+
+	show_highlight(iconName = null) {
+    this.show_indicator({ bgColor: COLOR_HIGHLIGHT, iconName: iconName });
+	}
+
+    show_hint(iconName = null) {
+    this.show_indicator({ bgColor: COLOR_HINT, iconName: iconName });
+	}
+
+  show_warning(iconName = null) {
+    this.show_indicator({ durationSeconds: 10, bgColor: COLOR_WARNING, iconName: iconName });
+  }
+});
+
 const HuaweiWmiIndicator = GObject.registerClass(
 class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system battery menu?
 	_init(path, settings) {
@@ -39,6 +129,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		this._battery_watching = false;
 		this._topping_off = false;
 		this._fn_led = false;
+		this._camera_indicator = null;
 
 		this._file_sys_str = "/sys/devices/platform/huawei-wmi/charge_control_thresholds";
 		this._file_def_str = "/etc/default/huawei-wmi/charge_control_thresholds";
@@ -170,13 +261,13 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 	}
 
 	_camera_ejected() {
-		this._show_osd('camera-photo-symbolic', _("Camera ejected"));
+		this._show_osd(CAMERA_ICONS.EJECTED, _("Camera ejected"));
 
 		if (this._camera_hint_timeout === null) {
 			this._camera_hint_prev_color = Main.panel._centerBox.get_background_color();
 			Main.panel._centerBox.set_style('background-color: #00AAD0;');
 
-			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 10, () => {
+			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
 				this._camera_hint_timeout = null;
 
 				if (this._camera_hint_prev_color !== null) {
@@ -186,10 +277,12 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 				return GLib.SOURCE_REMOVE;
 			});
 		}
+
+		this._camera_indicator?.show_info(CAMERA_ICONS.EJECTED);
 	}
 
 	_camera_inserted() {
-		this._show_osd('camera-hardware-disabled-symbolic', _("Camera inserted"));
+		this._show_osd(CAMERA_ICONS.INSERTED, _("Camera inserted"));
 
 		if (this._camera_hint_timeout !== null) {
 			GLib.Source.remove(this._camera_hint_timeout);
@@ -200,10 +293,12 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			Main.panel._centerBox.set_style(null);
 			this._camera_hint_prev_color = null;
 		}
+
+		this._camera_indicator?.show_info(CAMERA_ICONS.INSERTED);
 	}
 
 	_camera_attached() {
-		this._show_osd('camera-photo-symbolic', _("Camera attached"));
+		this._show_osd(CAMERA_ICONS.ATTACHED, _("Camera attached"));
 
 		if (this._camera_hint_timeout !== null) {
 			GLib.Source.remove(this._camera_hint_timeout);
@@ -214,10 +309,14 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			Main.panel._centerBox.set_style(null);
 			this._camera_hint_prev_color = null;
 		}
+
+		this._camera_indicator?.show_highlight(CAMERA_ICONS.ATTACHED);
 	}
 
 	_camera_detached() {
-		this._show_osd('camera-hardware-disabled-symbolic', _("Camera detached"));
+		this._show_osd(CAMERA_ICONS.DETACHED, _("Camera detached"));
+
+		this._camera_indicator?.show_hint(CAMERA_ICONS.DETACHED);
 	}
 
 	_update() {
@@ -395,13 +494,26 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 export default class HuaweiWmiExtension extends Extension {
 	enable() {
+	  this._camera_indicator = new CameraIndicator();
+	  Main.panel.addToStatusArea(this.uuid + '-camera', this._camera_indicator, -1, 'center');
+
+		this._camera_indicator_dummy = new CameraIndicator();
+		Main.panel.addToStatusArea(this.uuid + '-camera-dummy', this._camera_indicator_dummy, 0, 'center');
+
 		this._indicator = new HuaweiWmiIndicator(this.path, this.getSettings());
+		this._indicator._camera_indicator = this._camera_indicator;
 		Main.panel.addToStatusArea(this.uuid, this._indicator);
 	}
 
 	disable() {
 		this._indicator.destroy();
 		this._indicator = null;
+
+		this._camera_indicator.destroy();
+		this._camera_indicator = null;
+
+		this._camera_indicator_dummy.destroy();
+		this._camera_indicator_dummy = null;
 	}
 }
 

--- a/extension.js
+++ b/extension.js
@@ -32,10 +32,10 @@ class NonClosingPopupSwitchMenuItem extends PopupMenu.PopupSwitchMenuItem {
 });
 
 const BLUE_GLOW_STYLE = `
-    background-color: transparent;
-    box-shadow: inset 0 8px 6px -4px rgba(0, 200, 255, 0.9);
-    border-radius: 0 0 99px 99px;
-    border: none;
+	background-color: transparent;
+	box-shadow: inset 0 8px 6px -4px rgba(0, 200, 255, 0.9);
+	border-radius: 0 0 99px 99px;
+	border: none;
 `;
 
 const BLUE_GLOW_BLINKING_INTERVAL = 1000;
@@ -43,11 +43,11 @@ const BLUE_GLOW_BLINKING_INTERVAL = 1000;
 const CAMERA_NOTIFICATION_DURATION = 10;
 
 const CAMERA_ICONS = {
-    EJECTED: 'camera-photo-symbolic',
-    INSERTED: 'camera-hardware-disabled-symbolic',
-    ATTACHED: 'camera-photo-symbolic',
-    DETACHED: 'camera-hardware-disabled-symbolic',
-    DEFAULT: 'camera-photo-symbolic'
+	EJECTED: 'camera-photo-symbolic',
+	INSERTED: 'camera-hardware-disabled-symbolic',
+	ATTACHED: 'camera-photo-symbolic',
+	DETACHED: 'camera-hardware-disabled-symbolic',
+	DEFAULT: 'camera-photo-symbolic'
 };
 
 const COLOR_HIGHLIGHT = '#3D7FFF';
@@ -70,14 +70,14 @@ class CameraIndicator extends PanelMenu.Button {
 		});
 
 		this._icon_box = new St.BoxLayout({
-		  style_class: 'panel-status-menu-box',
+			style_class: 'panel-status-menu-box',
 		});
 
 		this._icon_box.add_child(this.icon);
 		this.add_child(this._icon_box);
 
 		this.opacity = 0;
-    this.reactive = false;
+		this.reactive = false;
 	}
 
 	destroy() {
@@ -91,43 +91,43 @@ class CameraIndicator extends PanelMenu.Button {
 	show_indicator({ durationSeconds = CAMERA_NOTIFICATION_DURATION, bgColor = null, color = null, iconName = null} = {}) {
 		if (iconName) this.icon.icon_name = iconName;
 		this.set_style(`
-      background-color: ${bgColor};
-      color: ${color};
-      transition-duration: 0ms;
-    `);
+			background-color: ${bgColor};
+			color: ${color};
+			transition-duration: 0ms;
+		`);
 
 		this.opacity = 255;
-    this.reactive = true;
+		this.reactive = true;
 
-        if (this._timeout !== null) {
+		if (this._timeout !== null) {
 			GLib.Source.remove(this._timeout);
 		}
 
 		this._timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, durationSeconds, () => {
 			this._timeout = null;
 			this.opacity = 0;
-      this.reactive = false;
- 			this.set_style(null);
+			this.reactive = false;
+			this.set_style(null);
 			this.icon.icon_name = CAMERA_ICONS.DEFAULT;
 			return GLib.SOURCE_REMOVE;
 		});
 	}
 
 	show_info(iconName = null) {
-    this.show_indicator({ iconName: iconName });
+		this.show_indicator({ iconName: iconName });
 	}
 
 	show_highlight(iconName = null) {
-    this.show_indicator({ bgColor: COLOR_HIGHLIGHT, iconName: iconName });
+		this.show_indicator({ bgColor: COLOR_HIGHLIGHT, iconName: iconName });
 	}
 
-    show_hint(iconName = null) {
-    this.show_indicator({ bgColor: COLOR_HINT, iconName: iconName });
+	show_hint(iconName = null) {
+		this.show_indicator({ bgColor: COLOR_HINT, iconName: iconName });
 	}
 
-  show_warning(iconName = null) {
-    this.show_indicator({ durationSeconds: 10, bgColor: COLOR_WARNING, iconName: iconName });
-  }
+	show_warning(iconName = null) {
+		this.show_indicator({ durationSeconds: 10, bgColor: COLOR_WARNING, iconName: iconName });
+	}
 });
 
 const HuaweiWmiIndicator = GObject.registerClass(
@@ -273,26 +273,26 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 	_camera_ejected() {
 		this._show_osd(CAMERA_ICONS.EJECTED, _("Camera ejected"));
 
-    if (this._camera_hint_timeout === null) {
-      let isGlowVisible = true;
-      Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
+		if (this._camera_hint_timeout === null) {
+			let isGlowVisible = true;
+			Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
 
-      this._camera_blink_timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, BLUE_GLOW_BLINKING_INTERVAL, () => {
-          isGlowVisible = !isGlowVisible;
-          Main.panel._centerBox.set_style(isGlowVisible ? BLUE_GLOW_STYLE : null);
-          return GLib.SOURCE_CONTINUE;
-      });
+			this._camera_blink_timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, BLUE_GLOW_BLINKING_INTERVAL, () => {
+				isGlowVisible = !isGlowVisible;
+				Main.panel._centerBox.set_style(isGlowVisible ? BLUE_GLOW_STYLE : null);
+				return GLib.SOURCE_CONTINUE;
+			});
 
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
 				if (this._camera_blink_timer) {
-          GLib.Source.remove(this._camera_blink_timer);
-          this._camera_blink_timer = null;
-        }
+					GLib.Source.remove(this._camera_blink_timer);
+					this._camera_blink_timer = null;
+				}
 				this._camera_hint_timeout = null;
 				Main.panel._centerBox.set_style(null);
 
-        this._camera_indicator?.show_warning(CAMERA_ICONS.EJECTED);
-        this._show_osd(CAMERA_ICONS.EJECTED, _("No Camera detected"));
+				this._camera_indicator?.show_warning(CAMERA_ICONS.EJECTED);
+				this._show_osd(CAMERA_ICONS.EJECTED, _("No Camera detected"));
 
 				return GLib.SOURCE_REMOVE;
 			});
@@ -312,7 +312,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		if (this._camera_blink_timer) {
 			GLib.Source.remove(this._camera_blink_timer);
 			this._camera_blink_timer = null;
-    }
+		}
 
 		Main.panel._centerBox.set_style(null);
 
@@ -342,7 +342,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 		this._camera_indicator?.show_hint(CAMERA_ICONS.DETACHED);
 
-  		if (this._camera_hint_timeout === null) {
+		if (this._camera_hint_timeout === null) {
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
 				this._camera_hint_timeout = null;
 				this._camera_indicator?.show_warning(CAMERA_ICONS.DETACHED);
@@ -527,8 +527,8 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 export default class HuaweiWmiExtension extends Extension {
 	enable() {
-	  this._camera_indicator = new CameraIndicator();
-	  Main.panel.addToStatusArea(this.uuid + '-camera', this._camera_indicator, -1, 'center');
+		this._camera_indicator = new CameraIndicator();
+		Main.panel.addToStatusArea(this.uuid + '-camera', this._camera_indicator, -1, 'center');
 
 		this._camera_indicator_dummy = new CameraIndicator();
 		Main.panel.addToStatusArea(this.uuid + '-camera-dummy', this._camera_indicator_dummy, 0, 'center');

--- a/extension.js
+++ b/extension.js
@@ -191,7 +191,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 		this._fn_led_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT_IDLE, 250, () => this._update_fn_led() || true);
 
 		this._camera_hint_timeout = null;
-		this._camera_blink_timer = null;
+		this._camera_glow_timer = null;
 
 		this._bind_keys(settings);
 
@@ -203,7 +203,7 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 
 		if (this._fullscreen_changed_s !== null) Display.disconnect(this._fullscreen_changed_s);
 		if (this._fn_led_timeout !== null) GLib.Source.remove(this._fn_led_timeout);
-		if (this._camera_blink_timer) GLib.Source.remove(this._camera_blink_timer);
+		if (this._camera_glow_timer) GLib.Source.remove(this._camera_glow_timer);
 		if (this._camera_hint_timeout !== null) GLib.Source.remove(this._camera_hint_timeout);
 		Main.panel._centerBox.set_style(null);
 
@@ -277,16 +277,16 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			let isGlowVisible = true;
 			Main.panel._centerBox.set_style(BLUE_GLOW_STYLE);
 
-			this._camera_blink_timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, BLUE_GLOW_BLINKING_INTERVAL, () => {
+			this._camera_glow_timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, BLUE_GLOW_BLINKING_INTERVAL, () => {
 				isGlowVisible = !isGlowVisible;
 				Main.panel._centerBox.set_style(isGlowVisible ? BLUE_GLOW_STYLE : null);
 				return GLib.SOURCE_CONTINUE;
 			});
 
 			this._camera_hint_timeout = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, CAMERA_NOTIFICATION_DURATION, () => {
-				if (this._camera_blink_timer) {
-					GLib.Source.remove(this._camera_blink_timer);
-					this._camera_blink_timer = null;
+				if (this._camera_glow_timer) {
+					GLib.Source.remove(this._camera_glow_timer);
+					this._camera_glow_timer = null;
 				}
 				this._camera_hint_timeout = null;
 				Main.panel._centerBox.set_style(null);
@@ -309,9 +309,9 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			this._camera_hint_timeout = null;
 		}
 
-		if (this._camera_blink_timer) {
-			GLib.Source.remove(this._camera_blink_timer);
-			this._camera_blink_timer = null;
+		if (this._camera_glow_timer) {
+			GLib.Source.remove(this._camera_glow_timer);
+			this._camera_glow_timer = null;
 		}
 
 		Main.panel._centerBox.set_style(null);
@@ -327,9 +327,9 @@ class HuaweiWmiIndicator extends PanelMenu.Button { // TODO: move to system batt
 			this._camera_hint_timeout = null;
 		}
 
-		if (this._camera_blink_timer) {
-			GLib.Source.remove(this._camera_blink_timer);
-			this._camera_blink_timer = null;
+		if (this._camera_glow_timer) {
+			GLib.Source.remove(this._camera_glow_timer);
+			this._camera_glow_timer = null;
 		}
 
 		Main.panel._centerBox.set_style(null);


### PR DESCRIPTION
Change the visual hint of the camera statein the top bar: Instead of coloring the entire center box (dateTime) background using a dedicated camera indicator icon with background coloring, resembling the original Honor indicator more closely.

<img width="246" height="54" alt="Bildschirmfoto vom 2026-04-06 00-15-37" src="https://github.com/user-attachments/assets/7c09b93f-22a6-4587-8892-348249385e5a" />

### Key Changes:
* Added a dedicated camera icon with a pill background to the center box in the status bar upon state change. The clock will stay centered perfectly due to a dummy that will compensate the offset of the actual icon + instead of showing and hiding the icon, the opacity is changed, which will further prevent any clock shifting. Transition time is set to 0 ms to avoid any glitches of the background coloring upon state change. Icons are aligned with the OSD.
* Removed the old background coloring of the center box (dateTime) + `Cogl` dependency as it is now obsolete,.

Supersedes/Closes #12